### PR TITLE
Add I2C async traits

### DIFF
--- a/src/delay.rs
+++ b/src/delay.rs
@@ -8,7 +8,7 @@ use core::future::Future;
 /// implement this trait for different types of `UXX`.
 pub trait AsyncDelayMs<UXX> {
     /// Delay future for polling on completion
-    type DelayFuture<'f>: Future<Output=()>;
+    type DelayFuture<'f>: Future<Output = ()>;
 
     /// Pauses execution for `ms` milliseconds
     fn async_delay_ms(&mut self, ms: UXX) -> Self::DelayFuture<'_>;
@@ -20,7 +20,7 @@ pub trait AsyncDelayMs<UXX> {
 /// implement this trait for different types of `UXX`.
 pub trait AsyncDelayUs<UXX> {
     /// Delay future for polling on completion
-    type DelayFuture<'f>: Future<Output=()>;
+    type DelayFuture<'f>: Future<Output = ()>;
 
     /// Pauses execution for `us` microseconds
     fn async_delay_us(&mut self, us: UXX) -> Self::DelayFuture<'_>;
@@ -58,7 +58,7 @@ macro_rules! impl_delay_ms_for_ms_u32 {
                 self.async_delay_ms(ms as u32)
             }
         }
-    }
+    };
 }
 
 /// Implement `AsyncDelayUs<u16>`, `AsyncDelayUs<u8>` and `AsyncDelayUs<i32>`
@@ -93,7 +93,7 @@ macro_rules! impl_delay_us_for_us_u32 {
                 self.async_delay_us(us as u32)
             }
         }
-    }
+    };
 }
 
 /// Implement `AsyncDelayUs<u32>`, `AsyncDelayUs<u16>`, `AsyncDelayUs<u8>` and `AsyncDelayUs<i32>`
@@ -111,7 +111,7 @@ macro_rules! impl_delay_us_for_us_u64 {
         }
 
         $crate::impl_delay_us_for_us_u32!($delay);
-    }
+    };
 }
 
 /// Implement `AsyncDelayMs<u32>`, `AsyncDelayMs<u16>`, `AsyncDelayMs<u8>` and `AsyncDelayMs<i32>`
@@ -128,5 +128,5 @@ macro_rules! impl_delay_ms_for_us_u64 {
         }
 
         $crate::impl_delay_ms_for_ms_u32!($delay);
-    }
+    };
 }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,0 +1,42 @@
+use core::future::Future;
+
+/// I2C transfer. An `async` version of [`i2c::blocking::WriteRead`]
+///
+/// [`i2c::blocking::WriteRead`]: https://docs.rs/embedded-hal/0.2.4/embedded_hal/blocking/i2c/trait.WriteRead.html
+pub trait AsyncI2cTransfer {
+    /// I2C slave address width: for 7-bit should be `u8`, for 10-bit `u16`
+    type AddressWidth;
+
+    /// Transfer error
+    type Error;
+
+    /// Transfer future for polling on completion
+    type TransferFuture<'f>: Future<Output = Result<(), Self::Error>>;
+
+    /// Sends bytes to the slave. Returns the bytes received from the slave
+    fn async_transfer<'a>(
+        &'a mut self,
+        address: Self::AddressWidth,
+        tx_data: &'a [u8],
+        rx_data: &'a mut [u8],
+    ) -> Self::TransferFuture<'a>;
+}
+
+/// I2C write
+pub trait AsyncI2cWrite {
+    /// I2C slave address width: for 7-bit should be `u8`, for 10-bit `u16`
+    type AddressWidth;
+
+    /// Write error
+    type Error;
+
+    /// Write future for polling on completion
+    type WriteFuture<'f>: Future<Output = Result<(), Self::Error>>;
+
+    /// Sends bytes to the slave, ignoring all the incoming bytes
+    fn async_write<'a>(
+        &'a mut self,
+        address: Self::AddressWidth,
+        data: &'a [u8],
+    ) -> Self::WriteFuture<'_>;
+}

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -4,9 +4,6 @@ use core::future::Future;
 ///
 /// [`i2c::blocking::WriteRead`]: https://docs.rs/embedded-hal/0.2.4/embedded_hal/blocking/i2c/trait.WriteRead.html
 pub trait AsyncI2cTransfer {
-    /// I2C slave address width: for 7-bit should be `u8`, for 10-bit `u16`
-    type AddressWidth;
-
     /// Transfer error
     type Error;
 
@@ -16,7 +13,7 @@ pub trait AsyncI2cTransfer {
     /// Sends bytes to the slave. Returns the bytes received from the slave
     fn async_transfer<'a>(
         &'a mut self,
-        address: Self::AddressWidth,
+        address: u16,
         tx_data: &'a [u8],
         rx_data: &'a mut [u8],
     ) -> Self::TransferFuture<'a>;
@@ -24,9 +21,6 @@ pub trait AsyncI2cTransfer {
 
 /// I2C write
 pub trait AsyncI2cWrite {
-    /// I2C slave address width: for 7-bit should be `u8`, for 10-bit `u16`
-    type AddressWidth;
-
     /// Write error
     type Error;
 
@@ -36,7 +30,7 @@ pub trait AsyncI2cWrite {
     /// Sends bytes to the slave, ignoring all the incoming bytes
     fn async_write<'a>(
         &'a mut self,
-        address: Self::AddressWidth,
+        address: u16,
         data: &'a [u8],
     ) -> Self::WriteFuture<'_>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![feature(generic_associated_types)]
 
 pub mod delay;
+pub mod i2c;
 pub mod prelude;
 pub mod serial;
 pub mod spi;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -5,12 +5,12 @@
 
 pub use crate::delay::{
     AsyncDelayMs as _async_embedded_traits_delay_AsyncDelayMs,
-    AsyncDelayUs as _async_embedded_traits_delay_AsyncDelayUs
+    AsyncDelayUs as _async_embedded_traits_delay_AsyncDelayUs,
 };
 
 pub use crate::serial::{
     AsyncRead as _async_embedded_traits_serial_AsyncRead,
-    AsyncWrite as _async_embedded_traits_serial_AsyncWrite
+    AsyncWrite as _async_embedded_traits_serial_AsyncWrite,
 };
 
 pub use crate::spi::{

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -5,9 +5,9 @@ pub trait AsyncRead {
     /// Read error
     type Error;
     /// Read byte future for polling on completion
-    type ReadByteFuture<'f>: Future<Output=Result<u8, Self::Error>>;
+    type ReadByteFuture<'f>: Future<Output = Result<u8, Self::Error>>;
     /// Read future for polling on completion
-    type ReadFuture<'f>: Future<Output=Result<(), Self::Error>>;
+    type ReadFuture<'f>: Future<Output = Result<(), Self::Error>>;
 
     /// Reads a single byte from the serial interface
     fn async_read_byte(&mut self) -> Self::ReadByteFuture<'_>;
@@ -21,11 +21,11 @@ pub trait AsyncWrite {
     /// Write error
     type Error;
     /// Write byte future for polling on completion
-    type WriteByteFuture<'f>: Future<Output=Result<(), Self::Error>>;
+    type WriteByteFuture<'f>: Future<Output = Result<(), Self::Error>>;
     /// Write future for polling on completion
-    type WriteFuture<'f>: Future<Output=Result<(), Self::Error>>;
+    type WriteFuture<'f>: Future<Output = Result<(), Self::Error>>;
     /// Flush future for polling on completion
-    type FlushFuture<'f>: Future<Output=Result<(), Self::Error>>;
+    type FlushFuture<'f>: Future<Output = Result<(), Self::Error>>;
 
     /// Writes a single byte to the serial interface
     /// When the future completes, data may not be fully transmitted.
@@ -44,8 +44,8 @@ pub trait AsyncWrite {
 pub mod read {
     use crate::serial::AsyncRead;
     use core::future::Future;
-    use core::task::{Context, Poll};
     use core::pin::Pin;
+    use core::task::{Context, Poll};
 
     /// Marker trait to opt into default async read implementation
     ///
@@ -62,16 +62,14 @@ pub mod read {
         type ReadFuture<'f> = DefaultReadFuture<'f, S>;
 
         fn async_read_byte(&mut self) -> Self::ReadByteFuture<'_> {
-            DefaultReadByteFuture {
-                serial: self
-            }
+            DefaultReadByteFuture { serial: self }
         }
 
         fn async_read<'a>(&'a mut self, data: &'a mut [u8]) -> Self::ReadFuture<'a> {
             DefaultReadFuture {
                 serial: self,
                 data,
-                offset: 0
+                offset: 0,
             }
         }
     }
@@ -112,10 +110,10 @@ pub mod read {
                         self.data[offset] = byte;
                         self.offset += 1;
                         continue;
-                    },
+                    }
                     Err(nb::Error::Other(e)) => {
                         return Poll::Ready(Err(e));
-                    },
+                    }
                     Err(nb::Error::WouldBlock) => {
                         cx.waker().wake_by_ref();
                         return Poll::Pending;
@@ -130,8 +128,8 @@ pub mod read {
 pub mod write {
     use crate::serial::AsyncWrite;
     use core::future::Future;
-    use core::task::{Context, Poll};
     use core::pin::Pin;
+    use core::task::{Context, Poll};
 
     /// Marker trait to opt into default async write implementation
     ///
@@ -149,23 +147,15 @@ pub mod write {
         type FlushFuture<'f> = DefaultFlushFuture<'f, S>;
 
         fn async_write_byte(&mut self, byte: u8) -> Self::WriteByteFuture<'_> {
-            DefaultWriteByteFuture {
-                serial: self,
-                byte
-            }
+            DefaultWriteByteFuture { serial: self, byte }
         }
 
         fn async_write<'a>(&'a mut self, data: &'a [u8]) -> DefaultWriteFuture<'a, S> {
-            DefaultWriteFuture {
-                serial: self,
-                data,
-            }
+            DefaultWriteFuture { serial: self, data }
         }
 
         fn async_flush(&mut self) -> DefaultFlushFuture<'_, S> {
-            DefaultFlushFuture {
-                serial: self
-            }
+            DefaultFlushFuture { serial: self }
         }
     }
 
@@ -185,7 +175,7 @@ pub mod write {
                 Err(nb::Error::WouldBlock) => {
                     cx.waker().wake_by_ref();
                     Poll::Pending
-                },
+                }
             }
         }
     }
@@ -204,10 +194,8 @@ pub mod write {
                     Ok(()) => {
                         self.data = &self.data[1..];
                         continue;
-                    },
-                    Err(nb::Error::Other(e)) => {
-                        return Poll::Ready(Err(e))
-                    },
+                    }
+                    Err(nb::Error::Other(e)) => return Poll::Ready(Err(e)),
                     Err(nb::Error::WouldBlock) => {
                         cx.waker().wake_by_ref();
                         return Poll::Pending;


### PR DESCRIPTION
Here are the simplest possible traits for async I2C.

I've made a working PoC implementation with `embassy`, STM32's DMA, and a device driver [adapted](https://github.com/eupn/axp173-rs/commit/adda58b07c34f209030ba5577e187417c655f600) to use these traits with `async/.await` syntax.

I hope you don't mind that I also did run the `rustfmt` in this branch. For a better experience, please review commit-by-commit.